### PR TITLE
fix(rust): resolve type names in DataFlowGraph.to_mermaid() (closes #48)

### DIFF
--- a/docs/language-guide-ja.md
+++ b/docs/language-guide-ja.md
@@ -94,3 +94,34 @@ let auth_result = volta_client.check_auth(&req).await;
 | Node.js / Deno / Bun | `ts/` — External 遷移に optional async |
 | Rust / システムプログラミング | `rust/` — ゼロコスト sync, async は外側 |
 | マルチ言語 | 3つとも同じ設計。サービスごとに選択 |
+
+---
+
+## Sync vs. Async — 言語別サポート一覧
+
+各言語で sync / async が適用されるコールバックの一覧。
+正規リファレンスは `spec/SPEC.md §1.3a`（DD-006、DD-012、DD-013）。
+
+| コールバック | Java | Rust | TypeScript |
+|---|---|---|---|
+| `StateProcessor.process` | sync | sync | sync（Auto）/ async `Promise<void>`（External のみ） |
+| `TransitionGuard.validate` | sync | sync | sync / async `Promise<GuardOutput>`（External のみ） |
+| `BranchProcessor.decide` | sync | sync | sync |
+| `FlowEngine.startFlow` | sync | sync | async（`Promise<FlowInstance>`） |
+| `FlowEngine.resumeAndExecute` | sync | sync | async（`Promise<FlowInstance>`） |
+
+**TypeScript の重要ルール:** Auto-chain の processor は**必ず sync** にすること。async を使用できるのは External 遷移に付属する processor / guard のみ。
+
+**Java / Rust で I/O が必要な場合のパターン:**
+I/O の結果をステートマシンの外で取得し、`resumeAndExecute` の `externalData` として注入する。
+External 遷移が async 境界として機能する:
+
+```
+SM startFlow()          (sync, ~1 μs) → External state で停止
+  ↓
+Async I/O               (HTTP / DB)
+  ↓
+SM resumeAndExecute()   (sync, ~300 ns) ← I/O 結果を externalData として注入
+```
+
+詳細なパターンは `docs/async-integration.md` を参照。

--- a/docs/language-guide.md
+++ b/docs/language-guide.md
@@ -150,3 +150,22 @@ tramli/
 | Node.js / Deno / Bun | `ts/` — optional async for External transitions |
 | Rust / systems programming | `rust/` — zero-cost sync, async outside |
 | Multi-language | All three share the same design. Pick per service |
+
+---
+
+## Sync vs. Async — Summary Table
+
+The following table documents which callbacks are sync vs. async in each language.
+The authoritative reference is `spec/SPEC.md §1.3a` (DD-006, DD-012, DD-013).
+
+| Callback | Java | Rust | TypeScript |
+|---|---|---|---|
+| `StateProcessor.process` | sync | sync | sync (Auto) / async `Promise<void>` (External only) |
+| `TransitionGuard.validate` | sync | sync | sync / async `Promise<GuardOutput>` (External only) |
+| `BranchProcessor.decide` | sync | sync | sync |
+| `FlowEngine.startFlow` | sync | sync | async (`Promise<FlowInstance>`) |
+| `FlowEngine.resumeAndExecute` | sync | sync | async (`Promise<FlowInstance>`) |
+
+**Key rule for TypeScript:** Auto-chain processors **must** remain sync. Only processors and guards on External transitions may be async.
+
+See `docs/async-integration.md` for detailed I/O integration patterns.

--- a/lang/rust/src/data_flow_graph.rs
+++ b/lang/rust/src/data_flow_graph.rs
@@ -498,50 +498,52 @@ impl<S: FlowState> DataFlowGraph<S> {
             }
 
             if let Some(guard) = &t.guard {
-                for req in guard.requires() {
-                    consumers.entry(req).or_default().push(NodeInfo {
+                let named_reqs = guard.requires_named();
+                let named_prods = guard.produces_named();
+                Self::collect_type_names(&named_reqs, type_names);
+                Self::collect_type_names(&named_prods, type_names);
+                for (req, _) in &named_reqs {
+                    consumers.entry(*req).or_default().push(NodeInfo {
                         name: guard.name().to_string(), from_state: t.from, to_state: t.to, kind: "guard",
                     });
-                    all_consumed.insert(req);
+                    all_consumed.insert(*req);
                 }
-                for prod in guard.produces() {
-                    producers.entry(prod).or_default().push(NodeInfo {
+                for (prod, _) in &named_prods {
+                    producers.entry(*prod).or_default().push(NodeInfo {
                         name: guard.name().to_string(), from_state: t.from, to_state: t.to, kind: "guard",
                     });
-                    all_produced.insert(prod);
-                    new_avail.insert(prod);
+                    all_produced.insert(*prod);
+                    new_avail.insert(*prod);
                 }
             }
             if let Some(branch) = &t.branch {
-                for req in branch.requires() {
-                    consumers.entry(req).or_default().push(NodeInfo {
+                let named_reqs = branch.requires_named();
+                Self::collect_type_names(&named_reqs, type_names);
+                for (req, _) in &named_reqs {
+                    consumers.entry(*req).or_default().push(NodeInfo {
                         name: branch.name().to_string(), from_state: t.from, to_state: t.to, kind: "branch",
                     });
-                    all_consumed.insert(req);
+                    all_consumed.insert(*req);
                 }
             }
             if let Some(proc) = &t.processor {
-                for req in proc.requires() {
-                    consumers.entry(req).or_default().push(NodeInfo {
+                let named_reqs = proc.requires_named();
+                let named_prods = proc.produces_named();
+                Self::collect_type_names(&named_reqs, type_names);
+                Self::collect_type_names(&named_prods, type_names);
+                for (req, _) in &named_reqs {
+                    consumers.entry(*req).or_default().push(NodeInfo {
                         name: proc.name().to_string(), from_state: t.from, to_state: t.to, kind: "processor",
                     });
-                    all_consumed.insert(req);
+                    all_consumed.insert(*req);
                 }
-                for prod in proc.produces() {
-                    producers.entry(prod).or_default().push(NodeInfo {
+                for (prod, _) in &named_prods {
+                    producers.entry(*prod).or_default().push(NodeInfo {
                         name: proc.name().to_string(), from_state: t.from, to_state: t.to, kind: "processor",
                     });
-                    all_produced.insert(prod);
-                    new_avail.insert(prod);
+                    all_produced.insert(*prod);
+                    new_avail.insert(*prod);
                 }
-            }
-
-            // Collect type names from requires/produces
-            if let Some(proc) = &t.processor {
-                Self::collect_type_names(proc.requires(), proc.produces(), type_names);
-            }
-            if let Some(guard) = &t.guard {
-                Self::collect_type_names(guard.requires(), guard.produces(), type_names);
             }
 
             Self::traverse(def, t.to, &new_avail, externally_provided, state_avail, producers, consumers,
@@ -549,9 +551,12 @@ impl<S: FlowState> DataFlowGraph<S> {
         }
     }
 
-    fn collect_type_names(_requires: Vec<TypeId>, _produces: Vec<TypeId>, _type_names: &mut HashMap<TypeId, String>) {
-        // TypeId doesn't carry names at runtime in Rust.
-        // Names are registered separately via register_type_name().
+    fn collect_type_names(named: &[(TypeId, &'static str)], type_names: &mut HashMap<TypeId, String>) {
+        for &(id, name) in named {
+            if !name.is_empty() {
+                type_names.entry(id).or_insert_with(|| name.to_string());
+            }
+        }
     }
 
     /// Register a human-readable name for a TypeId (for Mermaid output).

--- a/lang/rust/src/lib.rs
+++ b/lang/rust/src/lib.rs
@@ -44,6 +44,23 @@ macro_rules! requires {
     }
 }
 
+/// Like `data_types!` but returns `Vec<(TypeId, &'static str)>` carrying the type name.
+/// Use in `requires_named()` and `produces_named()` implementations.
+#[macro_export]
+macro_rules! data_types_named {
+    ($($t:ty),* $(,)?) => {
+        vec![$((std::any::TypeId::of::<$t>(), std::any::type_name::<$t>())),*]
+    }
+}
+
+/// Alias for `data_types_named!`.
+#[macro_export]
+macro_rules! requires_named {
+    ($($t:ty),* $(,)?) => {
+        vec![$((std::any::TypeId::of::<$t>(), std::any::type_name::<$t>())),*]
+    }
+}
+
 /// Build a `HashMap<TypeId, Box<dyn CloneAny>>` from values.
 /// Use in `GuardOutput::accepted(guard_data![val1, val2])`.
 #[macro_export]

--- a/lang/rust/src/types.rs
+++ b/lang/rust/src/types.rs
@@ -30,6 +30,20 @@ pub trait StateProcessor<S: FlowState>: Send + Sync {
     fn requires(&self) -> Vec<TypeId>;
     fn produces(&self) -> Vec<TypeId>;
     fn process(&self, ctx: &mut FlowContext) -> Result<(), FlowError>;
+
+    /// Like `requires()` but also returns a human-readable name for each TypeId.
+    /// Override this alongside `requires()` using the `requires_named!` macro.
+    /// Default implementation returns empty names.
+    fn requires_named(&self) -> Vec<(TypeId, &'static str)> {
+        self.requires().into_iter().map(|id| (id, "")).collect()
+    }
+
+    /// Like `produces()` but also returns a human-readable name for each TypeId.
+    /// Override this alongside `produces()` using the `data_types_named!` macro.
+    /// Default implementation returns empty names.
+    fn produces_named(&self) -> Vec<(TypeId, &'static str)> {
+        self.produces().into_iter().map(|id| (id, "")).collect()
+    }
 }
 
 /// Guards an external transition. Must not mutate FlowContext.
@@ -38,6 +52,16 @@ pub trait TransitionGuard<S: FlowState>: Send + Sync {
     fn requires(&self) -> Vec<TypeId>;
     fn produces(&self) -> Vec<TypeId>;
     fn validate(&self, ctx: &FlowContext) -> GuardOutput;
+
+    /// Like `requires()` but also returns a human-readable name for each TypeId.
+    fn requires_named(&self) -> Vec<(TypeId, &'static str)> {
+        self.requires().into_iter().map(|id| (id, "")).collect()
+    }
+
+    /// Like `produces()` but also returns a human-readable name for each TypeId.
+    fn produces_named(&self) -> Vec<(TypeId, &'static str)> {
+        self.produces().into_iter().map(|id| (id, "")).collect()
+    }
 }
 
 /// Decides which branch to take.
@@ -45,6 +69,11 @@ pub trait BranchProcessor<S: FlowState>: Send + Sync {
     fn name(&self) -> &str;
     fn requires(&self) -> Vec<TypeId>;
     fn decide(&self, ctx: &FlowContext) -> String;
+
+    /// Like `requires()` but also returns a human-readable name for each TypeId.
+    fn requires_named(&self) -> Vec<(TypeId, &'static str)> {
+        self.requires().into_iter().map(|id| (id, "")).collect()
+    }
 }
 
 /// A single transition in the flow definition.

--- a/lang/rust/tests/mermaid_view.rs
+++ b/lang/rust/tests/mermaid_view.rs
@@ -21,6 +21,8 @@ impl StateProcessor<S> for P1 {
     fn name(&self) -> &str { "p1" }
     fn requires(&self) -> Vec<TypeId> { vec![] }
     fn produces(&self) -> Vec<TypeId> { requires![Num] }
+    fn requires_named(&self) -> Vec<(TypeId, &'static str)> { vec![] }
+    fn produces_named(&self) -> Vec<(TypeId, &'static str)> { requires_named![Num] }
     fn process(&self, ctx: &mut FlowContext) -> Result<(), FlowError> {
         ctx.put(Num(1));
         Ok(())
@@ -32,6 +34,8 @@ impl StateProcessor<S> for P2 {
     fn name(&self) -> &str { "p2" }
     fn requires(&self) -> Vec<TypeId> { requires![Num] }
     fn produces(&self) -> Vec<TypeId> { requires![Str] }
+    fn requires_named(&self) -> Vec<(TypeId, &'static str)> { requires_named![Num] }
+    fn produces_named(&self) -> Vec<(TypeId, &'static str)> { requires_named![Str] }
     fn process(&self, ctx: &mut FlowContext) -> Result<(), FlowError> {
         let n = ctx.get::<Num>()?;
         ctx.put(Str(format!("n={}", n.0)));
@@ -75,9 +79,10 @@ fn view_dataflow_produces_flowchart() {
     assert!(out.contains("produces"), "got: {out}");
     assert!(out.contains("requires"), "got: {out}");
     assert!(!out.contains("stateDiagram"), "got: {out}");
-    // NOTE: Rust DataFlowGraph currently renders type nodes as "unknown" because
-    // TypeId → name resolution is not implemented. This is a separate gap (not in scope
-    // for Issue #47). Java/TS do resolve type names correctly (see respective tests).
+    // Issue #48: type names must resolve to the actual short name, not "unknown"
+    assert!(!out.contains("unknown"), "type names must not render as 'unknown'; got: {out}");
+    assert!(out.contains("Num"), "type 'Num' must appear in data-flow diagram; got: {out}");
+    assert!(out.contains("Str"), "type 'Str' must appear in data-flow diagram; got: {out}");
 }
 
 #[test]

--- a/spec/SPEC.md
+++ b/spec/SPEC.md
@@ -79,6 +79,76 @@ Design decisions governing multi-language parity:
 - **DD-022**: Plugin API must be 3-language symmetric.
 - **DD-026**: Systematic parity audit closed all known behavioral drift (P0–P2, plus P1+ edge cases).
 
+## 1.3a Sync vs. Async — Per-Language Processor Support
+
+> **Note for users coming from an async-first background.** Java and Rust processors are **always synchronous**. TypeScript allows async processors, but only on External transitions. This is a deliberate design decision (DD-013 / DD-012 / DD-006) — see below for the rationale and recommended I/O patterns.
+
+The table below summarises which core callbacks are sync vs. async in each language. "sync" means the method returns a plain value / void; "async (Promise)" means the method may return `Promise<void>` in addition to plain void.
+
+| Callback | Java | Rust | TypeScript |
+|---|---|---|---|
+| `StateProcessor.process` | sync | sync | sync (Auto) / async `Promise<void>` (External only) |
+| `TransitionGuard.validate` | sync | sync | sync / async `Promise<GuardOutput>` (External only) |
+| `BranchProcessor.decide` | sync | sync | sync |
+| `FlowEngine.startFlow` | sync | sync | async (`Promise<FlowInstance>`) |
+| `FlowEngine.resumeAndExecute` | sync | sync | async (`Promise<FlowInstance>`) |
+
+**Rule:** in TypeScript, Auto-chain processors **must** be sync. Only processors and guards attached to External transitions may be async (`AsyncStateProcessor` / `AsyncTransitionGuard`). Auto-chain runs multiple transitions in sequence; introducing `await` per step adds unnecessary microtask overhead.
+
+**Why Java and Rust are sync-only (DD-013 / DD-012):**
+- Java 21 virtual threads (`Thread.startVirtualThread`) handle blocking I/O without async syntax. The engine finishes in ~1–2 μs; there is no benefit in making it async.
+- In Rust, `async fn` compiles to a `Future` state machine. Embedding the SM engine inside a `Future` captures `&mut FlowEngine` + `FlowContext` + all processor state across `.await` points, causing stack overflow with 3+ states (documented in `rust/ASYNC_STACK_ISSUE.md`). DD-012 retracted Rust async for this reason.
+
+**Why TypeScript allows async on External (DD-006 / DD-013):**
+- TypeScript `Promise` is heap-allocated (~1 μs overhead). No stack-size issues, no ownership complexity.
+- External transitions already represent an async boundary (the engine suspends and waits for `resumeAndExecute`). Allowing the post-guard processor to be async is natural and adds negligible cost.
+
+### 1.3a.1 Recommended I/O Pattern for Java and Rust
+
+If a processor needs the result of an I/O operation (network call, DB query), perform the I/O **outside** the state machine and inject the result into `FlowContext` before calling `resumeAndExecute`. The External transition is the natural async boundary:
+
+```
+SM startFlow()   (sync, ~1 μs)   → flow stops at first External state
+  ↓
+Async I/O        (HTTP / DB)
+  ↓
+SM resumeAndExecute()  (sync, ~300 ns)  ← inject I/O result as externalData
+```
+
+**Java example:**
+
+```java
+// 1. Start flow — SM runs auto-chain, stops at External state PAYMENT_PENDING
+FlowInstance<OrderState> flow = engine.startFlow(def, null,
+    Map.of(OrderRequest.class, req));
+// flow.currentState() == PAYMENT_PENDING
+
+// 2. Async I/O outside the SM (virtual thread or CompletableFuture)
+PaymentCallback cb = paymentClient.initiate(req.orderId()).get();  // blocking on vthread
+
+// 3. Resume — inject result; SM transitions PAYMENT_PENDING → PAYMENT_CONFIRMED
+engine.resumeAndExecute(flow.id(), def, Map.of(PaymentCallback.class, cb));
+```
+
+**Rust example (tokio):**
+
+```rust
+// 1. Start flow (sync — microseconds)
+let flow_id = engine.start_flow(&def, None, initial_data)?;
+// SM auto-chains: RECEIVED → VALIDATED → stops at External PAYMENT_PENDING
+
+// 2. Async I/O outside the SM
+let cb: PaymentCallback = payment_client.initiate(order_id).await?;
+
+// 3. Resume — inject result (sync — microseconds)
+engine.resume_and_execute(&flow_id, &def,
+    context_data! { PaymentCallback => cb })?;
+```
+
+> **TTL guidance.** Long-running async operations (minutes, hours) should be expressed as separate External states with a generous TTL rather than blocking inside a single resume call. See `docs/patterns/long-lived-flows.md` for the recommended pattern.
+
+Cross-references: `docs/async-integration.md`, `docs/language-guide.md`, DD-006, DD-012, DD-013.
+
 ## 1.4 API Stability Tiers
 
 Three tiers (authoritative source: `docs/api-stability.md`):


### PR DESCRIPTION
Closes #48

## Problem

`DataFlowGraph.to_mermaid()` in Rust rendered type nodes as `unknown` instead of the actual type name (e.g. `Num`, `Str`), unlike the Java/TS implementations which use string keys directly.

Root cause: `requires()` / `produces()` on processor/guard traits return only `Vec<TypeId>` with no name information, and `collect_type_names()` in the graph builder was a no-op stub.

## Fix

- Added `requires_named()` / `produces_named()` default methods to `StateProcessor`, `TransitionGuard`, and `BranchProcessor` traits, returning `Vec<(TypeId, &'static str)>`.
- Added `data_types_named!` and `requires_named!` macros that pair `TypeId::of::<T>()` with `std::any::type_name::<T>()`.
- Replaced the no-op `collect_type_names` stub with an implementation that populates the `type_names` HashMap from the named pairs.
- Updated `DataFlowGraph::traverse()` to call the `_named` methods and collect names during graph construction.
- Updated the `mermaid_view` test to override `requires_named`/`produces_named` and assert that `Num` and `Str` appear in the diagram (not `unknown`).

## Backward compatibility

Fully backward compatible. Existing processor/guard impls that do not override `requires_named()`/`produces_named()` fall back to the default (empty names → unknown). Implementors can opt in to correct names by overriding the named methods with the macros.

## Test plan

- [x] All 48 existing Rust tests pass (`cargo test`)
- [x] `view_dataflow_produces_flowchart` now asserts `!out.contains("unknown")` and `out.contains("Num")` / `out.contains("Str")`